### PR TITLE
fix(lint): isolate pydoclint to end docstring-parser-fork collision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,12 @@ jobs:
       # Docstring consistency: documented args/attributes must match the code.
       # Config lives in pyproject.toml ([tool.pydoclint]); vgi_rpc/ is fully
       # clean with no baseline, so any new violation fails immediately.
+      # Run isolated via uvx: pydoclint pulls docstring-parser-fork, which
+      # collides with the canonical docstring-parser in the project venv, so it
+      # is deliberately not a project dependency (see pyproject.toml). --python
+      # 3.13 is required so the parser understands the package's 3.13 syntax.
       - name: Docstring lint (pydoclint)
-        run: uv run pydoclint vgi_rpc/
+        run: uvx --python 3.13 --from pydoclint==0.8.7 pydoclint vgi_rpc/
 
       - name: Type check (mypy)
         run: uv run mypy vgi_rpc/ --any-exprs-report mypy-type-report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ The full process before committing code is
 
 1. Run `uv run ruff format .` on all files
 2. Run `uv run ruff check .` and resolve all errors
-3. Run `uv run pydoclint vgi_rpc/` and resolve all errors (docstring args/attributes must match the code; config in `[tool.pydoclint]`, no baseline — the tree is fully clean)
+3. Run `uvx --python 3.13 --from pydoclint==0.8.7 pydoclint vgi_rpc/` and resolve all errors (docstring args/attributes must match the code; config in `[tool.pydoclint]`, no baseline — the tree is fully clean). pydoclint runs isolated via `uvx` because its `docstring-parser-fork` dep collides with the canonical `docstring-parser` in the project venv — so it is intentionally not a project dependency.
 4. Run `uv run mypy vgi_rpc/` and resolve all errors
 5. Run `uv run ty check vgi_rpc/` and resolve all errors
 6. Run `uv run pytest` for all tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -237,15 +237,25 @@ dev = [
     "sentry-sdk>=2.0",
     "cryptography>=41.0",
     "pynacl>=1.5",
-    "pydoclint>=0.8",
     "hypothesis>=6.155.3",
 ]
+# pydoclint is intentionally NOT a project dependency. It depends on
+# `docstring-parser-fork`, which installs into the same `docstring_parser/`
+# import namespace as the canonical `docstring-parser` this package needs at
+# runtime (vgi_rpc/rpc/_types.py). When both land in one venv, whichever uv
+# installs last wins non-deterministically — and the fork-vs-canonical race
+# made docstring symbols (e.g. DocstringYields) appear/disappear across
+# unrelated dependency bumps, flaking the lint gate. Run pydoclint isolated:
+#   uvx --python 3.13 --from pydoclint==0.8.7 pydoclint vgi_rpc/
+# (CI uses the same invocation; --python 3.13 is required so the parser
+# understands this package's 3.13 syntax.)
 
 [tool.pydoclint]
 # Docstring consistency gate (complements ruff's `D` rules, which only check
 # docstring *shape*, not whether documented args/attributes match the code).
 # Enforced families: DOC001 (parse), DOC101/102/103 (arg<->signature), DOC4xx
-# (yields), DOC60x (dataclass attributes). Run via `uv run pydoclint vgi_rpc/`.
+# (yields), DOC60x (dataclass attributes). Run isolated (see note by the dev
+# group above): `uvx --python 3.13 --from pydoclint==0.8.7 pydoclint vgi_rpc/`.
 style = "google"
 # We keep types in signatures, not docstrings (Google style) — so don't ask for
 # them in docstrings, and don't try to match return/yield *types* against prose.

--- a/uv.lock
+++ b/uv.lock
@@ -529,15 +529,6 @@ wheels = [
 ]
 
 [[package]]
-name = "docstring-parser-fork"
-version = "0.0.14"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/bf/27f9cab2f0cd1d17a4420572088bbc19f36d726fbcf165edf226a8926dbc/docstring_parser_fork-0.0.14.tar.gz", hash = "sha256:a2743a63d8d36c09650594f7b4ab5b2758fee8629dcf794d1b221b23179baa5c", size = 34551, upload-time = "2025-09-07T17:27:38.272Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/50/98b146aea0f1cd7531d25f12bea69fa9ce8d1662124f93fb30dc4511b65e/docstring_parser_fork-0.0.14-py3-none-any.whl", hash = "sha256:4c544f234ef2cc2749a3df32b70c437d77888b1099143a1ad5454452c574b9af", size = 43063, upload-time = "2025-09-07T17:27:37.012Z" },
-]
-
-[[package]]
 name = "falcon"
 version = "4.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1862,19 +1853,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pydoclint"
-version = "0.8.7"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "docstring-parser-fork" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/bf/2e/e4df6b0cbb281cb6cf355f5d90b8c66939c7f3cd799c075fab23e0983dfb/pydoclint-0.8.7.tar.gz", hash = "sha256:1ce5055dfdaf2bc3c999d3ffd5494556b903b7090bb5fadac90819107f90629b", size = 199793, upload-time = "2026-06-22T01:24:20.117Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/d4/15fe5c3e66bbf3f60eb9c6ef7c2dca3931302f9acf317e65d70e7d8b338a/pydoclint-0.8.7-py3-none-any.whl", hash = "sha256:40f6b80e59129fe753f6a2f9edd76e4259c970eedc1ce3663adc43f54af439d3", size = 82963, upload-time = "2026-06-22T01:24:19.102Z" },
-]
-
-[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2620,7 +2598,6 @@ dev = [
     { name = "opentelemetry-api" },
     { name = "opentelemetry-sdk" },
     { name = "pyarrow-stubs" },
-    { name = "pydoclint" },
     { name = "pynacl" },
     { name = "pytest" },
     { name = "pytest-benchmark" },
@@ -2693,7 +2670,6 @@ dev = [
     { name = "opentelemetry-api", specifier = ">=1.20" },
     { name = "opentelemetry-sdk", specifier = ">=1.20" },
     { name = "pyarrow-stubs", specifier = ">=17.0" },
-    { name = "pydoclint", specifier = ">=0.8" },
     { name = "pynacl", specifier = ">=1.5" },
     { name = "pytest", specifier = ">=7.0" },
     { name = "pytest-benchmark", specifier = ">=4.0" },


### PR DESCRIPTION
## Problem

The Lint gate was flaky in a way that surfaced on the cryptography 48→49 Dependabot PR (#17): pydoclint crashed with

```
ImportError: cannot import name 'DocstringYields' from 'docstring_parser.common'
```

Root cause: **pydoclint depends on `docstring-parser-fork`**, which installs into the *same* `docstring_parser/` import namespace as the **canonical `docstring-parser`** that vgi_rpc imports at runtime (`rpc/_types.py`). With both in one venv, whichever uv installs **last** wins — non-deterministic. Unrelated dependency bumps reorder the install graph; when the canonical package shadows the fork, the symbols pydoclint needs disappear and it crashes. The bug was **latent on `main`** (the fork happened to win there), so it only appeared once #17 perturbed the order.

`docstring-parser-fork` is pulled in *only* by pydoclint:
```
docstring-parser-fork v0.0.14
└── pydoclint v0.8.7
    └── vgi-rpc (group: dev)
```

## Fix

Stop co-installing the fork with the canonical package: remove pydoclint from the dev group and run it **isolated** via uvx.

- **pyproject.toml** — drop `pydoclint>=0.8` from the dev group; document why; update the `[tool.pydoclint]` run note.
- **ci.yml** — `uvx --python 3.13 --from pydoclint==0.8.7 pydoclint vgi_rpc/` (the `--python 3.13` is required so the isolated parser understands the package's 3.13 syntax).
- **CLAUDE.md** — update the step-3 command.
- **uv.lock** — regenerated; `pydoclint` and `docstring-parser-fork` removed. The project venv now resolves only canonical `docstring-parser` 0.18.0.

## Verification

- Project venv now contains only `docstring_parser-0.18.0` (no fork).
- Runtime import `from docstring_parser import DocstringStyle, parse` → ok.
- `uvx --python 3.13 --from pydoclint==0.8.7 pydoclint vgi_rpc/` → 🎉 No violations.
- `ruff format --check`, `ruff check`, `mypy`, `ty` all clean.
- `pytest` (introspection/docstring/type subset) → 543 passed.

Unblocks #17, which will pass Lint deterministically once rebased on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)